### PR TITLE
Load the text tower of dual-registered composite configs

### DIFF
--- a/nnterp/standardized_transformer.py
+++ b/nnterp/standardized_transformer.py
@@ -17,6 +17,7 @@ from .utils import (
     DummyCache,
     try_with_scan,
 )
+from .text_tower import resolve_automodel
 from .rename_utils import (
     IOType,
     LayerAccessor,
@@ -73,6 +74,14 @@ class StandardizedTransformer(LanguageModel):
             tracing by setting attn_implementation="eager". Defaults to False.
         check_attn_probs_with_trace (bool, default True): If True, the model will be dispatched and a test will ensure that the attention probabilities returned sum to 1.
         rename_config (RenameConfig, default None): A RenameConfig object to use for renaming the model. If None, a default RenameConfig will be used.
+        text_tower (bool, default True): If True and ``model`` names a composite
+            multimodal checkpoint that *also* registers a text-only causal LM
+            (e.g. Qwen3.6-35B-A3B, ``model_type qwen3_5_moe``), load that text
+            tower through ``AutoModelForCausalLM``. The vision tower is not
+            loaded. Has no effect on ordinary text models or on genuine
+            multimodal-only checkpoints. Set False for nnsight's default
+            handling, which refuses such checkpoints and points at
+            ``VisionLanguageModel``.
     """
 
     num_layers: int
@@ -91,6 +100,7 @@ class StandardizedTransformer(LanguageModel):
         check_attn_probs_with_trace: bool = True,
         allow_multimodal: bool = False,
         rename_config: RenameConfig | None = None,
+        text_tower: bool = True,
         **kwargs,
     ):
         if remote:
@@ -117,6 +127,13 @@ class StandardizedTransformer(LanguageModel):
                 f"Updating default rename with user-provided rename: {user_rename}"
             )
             rename.update(user_rename)
+        # A composite multimodal config that also registers a text-only causal LM
+        # is loadable as its text tower, but nnsight refuses it on sight; opt out
+        # of that refusal rather than making the caller pre-load the module.
+        if text_tower and "automodel" not in kwargs:
+            automodel = resolve_automodel(model, trust_remote_code=trust_remote_code)
+            if automodel is not None:
+                kwargs["automodel"] = automodel
         super().__init__(
             model,
             attn_implementation=attn_implementation,

--- a/nnterp/tests/test_text_tower.py
+++ b/nnterp/tests/test_text_tower.py
@@ -97,7 +97,5 @@ def test_resolve_automodel_is_never_the_thing_that_fails_a_load(monkeypatch):
     def boom(*args, **kwargs):
         raise OSError("no such repo")
 
-    monkeypatch.setattr(
-        "transformers.AutoConfig.from_pretrained", boom, raising=True
-    )
+    monkeypatch.setattr("transformers.AutoConfig.from_pretrained", boom, raising=True)
     assert tt.resolve_automodel("definitely/not-a-real-repo") is None

--- a/nnterp/tests/test_text_tower.py
+++ b/nnterp/tests/test_text_tower.py
@@ -1,0 +1,103 @@
+"""Text-tower loading for dual-registered composite configs.
+
+These tests are offline and deterministic: the predicate under test reads only
+transformers' auto-mapping tables, and the model_types it is exercised on are
+discovered from those tables rather than hard-coded, so the tests describe the
+contract instead of pinning a transformers release.
+"""
+
+import pytest
+from transformers import AutoModelForCausalLM
+
+from nnterp.text_tower import (
+    TextTowerAutoModelForCausalLM,
+    resolve_automodel,
+    text_tower_is_available,
+)
+
+
+def _mappings():
+    try:
+        from transformers.models.auto.modeling_auto import (
+            MODEL_FOR_CAUSAL_LM_MAPPING_NAMES,
+            MODEL_FOR_IMAGE_TEXT_TO_TEXT_MAPPING_NAMES,
+        )
+    except ImportError:
+        pytest.skip("transformers does not expose the auto-mapping name tables")
+    return MODEL_FOR_CAUSAL_LM_MAPPING_NAMES, MODEL_FOR_IMAGE_TEXT_TO_TEXT_MAPPING_NAMES
+
+
+class _Config:
+    """The only thing the predicate reads off a config."""
+
+    def __init__(self, model_type):
+        self.model_type = model_type
+
+
+def _first(model_types):
+    return sorted(model_types)[0] if model_types else None
+
+
+def test_subclass_is_the_escape_hatch_nnsight_documents():
+    """nnsight stands down for a non-default automodel via an identity check.
+
+    ``LanguageModel._check_is_text_only`` returns early when
+    ``self.automodel is not AutoModelForCausalLM``. That identity is the whole
+    mechanism, so assert it directly.
+    """
+    assert TextTowerAutoModelForCausalLM is not AutoModelForCausalLM
+    assert issubclass(TextTowerAutoModelForCausalLM, AutoModelForCausalLM)
+
+
+def test_subclass_dispatches_identically_to_its_parent():
+    """Being a marker must not change which class gets built."""
+    assert (
+        TextTowerAutoModelForCausalLM._model_mapping
+        is AutoModelForCausalLM._model_mapping
+    )
+
+
+def test_dual_registered_config_offers_a_text_tower():
+    clm, itt = _mappings()
+    dual = _first(set(clm) & set(itt))
+    if dual is None:
+        pytest.skip("no dual-registered model_type in this transformers version")
+    assert text_tower_is_available(_Config(dual))
+
+
+def test_multimodal_only_config_offers_no_text_tower():
+    clm, itt = _mappings()
+    vlm_only = _first(set(itt) - set(clm))
+    if vlm_only is None:
+        pytest.skip("no multimodal-only model_type in this transformers version")
+    assert not text_tower_is_available(_Config(vlm_only))
+
+
+def test_plain_text_config_needs_no_special_handling():
+    clm, itt = _mappings()
+    text_only = _first(set(clm) - set(itt))
+    assert text_only is not None, "expected at least one text-only model_type"
+    assert not text_tower_is_available(_Config(text_only))
+
+
+def test_config_without_model_type_is_not_a_text_tower():
+    assert not text_tower_is_available(_Config(None))
+    assert not text_tower_is_available(object())
+
+
+def test_resolve_automodel_ignores_a_preloaded_module():
+    """A module was already built by the caller; there is nothing to resolve."""
+    assert resolve_automodel(object()) is None
+
+
+def test_resolve_automodel_is_never_the_thing_that_fails_a_load(monkeypatch):
+    """An unreadable config must fall through to nnsight, not raise here."""
+    import nnterp.text_tower as tt
+
+    def boom(*args, **kwargs):
+        raise OSError("no such repo")
+
+    monkeypatch.setattr(
+        "transformers.AutoConfig.from_pretrained", boom, raising=True
+    )
+    assert tt.resolve_automodel("definitely/not-a-real-repo") is None

--- a/nnterp/text_tower.py
+++ b/nnterp/text_tower.py
@@ -1,0 +1,99 @@
+"""Loading the text tower of a composite (vision-)language model.
+
+Some checkpoints ship one config that registers *both* a multimodal model and a
+text-only causal LM. ``Qwen/Qwen3.6-35B-A3B`` (``model_type qwen3_5_moe``) is the
+motivating case: transformers maps it to ``Qwen3_5MoeForConditionalGeneration``
+under ``AutoModelForImageTextToText`` **and** to ``Qwen3_5MoeForCausalLM`` under
+``AutoModelForCausalLM``.
+
+``nnsight.LanguageModel`` refuses any config registered with
+``AutoModelForImageTextToText`` (``LanguageModel._check_is_text_only``), on the
+premise that loading it through ``AutoModelForCausalLM`` would fail deep inside
+HuggingFace because the text fields are nested under ``config.text_config``.
+That premise holds for genuine VLMs such as ``llava`` or ``qwen2_vl``, whose
+``AutoModelForCausalLM`` mapping is empty — but not for a dual-registered
+config, where ``AutoModelForCausalLM`` resolves to the text tower and loads it
+cleanly.
+
+This module detects that case and opts out of the guard. nnsight's guard stands
+down for any non-default ``automodel``, so :class:`TextTowerAutoModelForCausalLM`
+opts in explicitly while resolving through the identical ``_model_mapping``.
+"""
+
+from __future__ import annotations
+
+from transformers import AutoModelForCausalLM
+
+from .logging import logger
+
+
+class TextTowerAutoModelForCausalLM(AutoModelForCausalLM):
+    """``AutoModelForCausalLM``, tagged so nnsight's multimodal guard stands down.
+
+    Behaviourally identical to its parent: auto classes dispatch on the
+    inherited ``_model_mapping``, and nnsight only ever calls ``from_config`` and
+    ``from_pretrained`` on the class it is given. The subclass exists solely so
+    that ``automodel is not AutoModelForCausalLM`` — the documented escape hatch
+    in ``nnsight.LanguageModel._check_is_text_only`` for callers who have chosen
+    their own automodel and do not want to be second-guessed.
+    """
+
+
+def text_tower_is_available(config) -> bool:
+    """Whether ``config`` is a composite config that also offers a text tower.
+
+    True only when the config's ``model_type`` is registered with **both**
+    ``AutoModelForImageTextToText`` and ``AutoModelForCausalLM``. A genuine
+    multimodal-only config (no causal-LM mapping) returns False, and so does an
+    ordinary text model (no image-text-to-text mapping) — the caller needs no
+    special handling in either case.
+    """
+    model_type = getattr(config, "model_type", None)
+    if not model_type:
+        return False
+    try:
+        from transformers.models.auto.modeling_auto import (
+            MODEL_FOR_CAUSAL_LM_MAPPING_NAMES,
+            MODEL_FOR_IMAGE_TEXT_TO_TEXT_MAPPING_NAMES,
+        )
+    except ImportError:  # pragma: no cover - very old/very new transformers
+        return False
+    return (
+        model_type in MODEL_FOR_IMAGE_TEXT_TO_TEXT_MAPPING_NAMES
+        and model_type in MODEL_FOR_CAUSAL_LM_MAPPING_NAMES
+    )
+
+
+def resolve_automodel(repo_id, trust_remote_code: bool = False):
+    """The automodel to hand nnsight for ``repo_id``, or None to keep its default.
+
+    Returns :class:`TextTowerAutoModelForCausalLM` when ``repo_id`` names a
+    dual-registered composite config, so the text tower is loaded and nnsight's
+    multimodal refusal does not fire. Returns None otherwise, including when the
+    config cannot be read — a failure to look ahead should never turn into a
+    failure to load, so the caller falls back to nnsight's own handling and its
+    error message.
+    """
+    if not isinstance(repo_id, str):
+        return None
+    try:
+        from transformers import AutoConfig
+
+        config = AutoConfig.from_pretrained(
+            repo_id, trust_remote_code=trust_remote_code
+        )
+    except Exception as e:  # noqa: BLE001 - diagnosis only; nnsight reports for real
+        logger.debug(
+            f"Could not read the config of {repo_id!r} to check for a text tower "
+            f"({type(e).__name__}: {e}). Leaving nnsight's automodel untouched."
+        )
+        return None
+    if not text_tower_is_available(config):
+        return None
+    logger.info(
+        f"{repo_id!r} (model_type {getattr(config, 'model_type', None)!r}) is a "
+        "composite multimodal config that also registers a text-only causal LM. "
+        "Loading the text tower via AutoModelForCausalLM; the vision tower is "
+        "not loaded. Pass text_tower=False to get nnsight's default handling."
+    )
+    return TextTowerAutoModelForCausalLM


### PR DESCRIPTION
## The problem

`StandardizedTransformer("Qwen/Qwen3.6-35B-A3B")` fails before any renaming happens:

```
ValueError: 'Qwen/Qwen3.6-35B-A3B' (qwen3_5_moe) is registered with
AutoModelForImageTextToText — it's a multimodal model so LanguageModel(...)
can't load it. Use VisionLanguageModel instead
```

nnsight's `LanguageModel._check_is_text_only` refuses any `model_type` in `MODEL_FOR_IMAGE_TEXT_TO_TEXT_MAPPING_NAMES`, on the premise that `AutoModelForCausalLM` would then fail because the text fields sit under `config.text_config`.

That premise does not hold for every such config:

| model_type | ImageTextToText | CausalLM |
|---|---|---|
| `qwen3_5_moe` | `Qwen3_5MoeForConditionalGeneration` | **`Qwen3_5MoeForCausalLM`** |
| `qwen2_vl` | `Qwen2VLForConditionalGeneration` | `None` |
| `llava` | `LlavaForConditionalGeneration` | `None` |

`qwen3_5_moe` is registered in **both** tables. `AutoModelForCausalLM` resolves to the text tower and loads it cleanly. Genuine VLMs have no causal-LM mapping at all, which is the case the guard is actually for — so the refusal is over-broad, and it locks nnterp out of a whole architecture family (Qwen3.6-35B-A3B and its siblings).

## What this does

`nnterp/text_tower.py` detects exactly that case — `model_type` present in both auto mappings — and opts out of the refusal using the escape hatch the guard documents for it: it stands down for any non-default `automodel`, so nnterp hands it a marker subclass of `AutoModelForCausalLM` that dispatches through the identical `_model_mapping`.

New `text_tower: bool = True` kwarg on `StandardizedTransformer`. Ordinary text models and multimodal-only configs take neither branch; `text_tower=False` restores nnsight's own handling. **The vision tower is never loaded**, by design.

A failure to read the config ahead of time returns `None` rather than raising, so looking ahead can never be the thing that fails a load — nnsight still reports the real error.

## Verified

On `tiny-random/qwen3.5-moe` (transformers 5.16.0, nnsight 0.7.0):

- loads as `Qwen3_5MoeForCausalLM`; `hasattr(model, "visual")` is `False`
- `num_layers` 4, `hidden_size` 8, `vocab_size` 248320, `num_heads` 8 all resolve — the existing `text_config()` helper already handles the composite config
- `token_embeddings`, `layers_output[0]` and `logits` all trace correctly
- 8 new offline unit tests (they discover model_types from the auto-mapping tables rather than hard-coding them, so they describe the contract instead of pinning a release)
- no regression: `gpt2`, `Maykeye/TinyLLama-v0` and `yujiepan/qwen3-moe-tiny-random` still load with full renaming validation

## Scope

This fixes loading only. `check_renaming=True` on this architecture then hits the *next* problem — `RenamingError: Could not find self_attn module`, because `layer_types = ([linear_attention] * 3 + [full_attention]) * 10` means `layers[0]` is a Gated DeltaNet layer with no `self_attn`. That is the hybrid-layer work in #18 and is deliberately not touched here.

## An alternative worth considering

The cleaner fix is upstream in nnsight — narrow the guard to refuse only when there is no causal-LM mapping to fall back on:

```diff
         try:
             from transformers.models.auto.modeling_auto import (
+                MODEL_FOR_CAUSAL_LM_MAPPING_NAMES,
                 MODEL_FOR_IMAGE_TEXT_TO_TEXT_MAPPING_NAMES,
             )
         except ImportError:
             return

         model_type = getattr(self.config, "model_type", None)
-        if model_type and model_type in MODEL_FOR_IMAGE_TEXT_TO_TEXT_MAPPING_NAMES:
+        if (
+            model_type
+            and model_type in MODEL_FOR_IMAGE_TEXT_TO_TEXT_MAPPING_NAMES
+            and model_type not in MODEL_FOR_CAUSAL_LM_MAPPING_NAMES
+        ):
             raise ValueError(
```

I applied that to nnsight 0.7.0 locally and confirmed `StandardizedTransformer(..., text_tower=False)` then loads the text tower with no nnterp involvement. Happy to file it there instead or as well — but nnterp needs to work against released nnsight either way, which is what this PR provides.

## Unrelated finding, reported separately

`yujiepan/qwen1.5-moe-tiny-random` — in nnterp's own `core_test_models` — fails to load under transformers 5.16 + fp32 with `RuntimeError: Expected inputs of BF16 type` from `torch._grouped_mm` on the fake-tensor path, so `scan()` fails and the `trace()` fallback then fails the IO check. Pre-existing at `b4a3127` and independent of this change (`qwen2_moe` is not dual-registered, so this code path never engages, and `text_tower=False` fails identically).

🤖 Generated with [Claude Code](https://claude.com/claude-code)