### PR TITLE
Fix #51: attentions_output/mlps_output returned residual-added states on BLOOM/MPT/DBRX

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -73,6 +73,7 @@ nnterp is a mechanistic interpretability library built on top of nnsight, provid
 - `layers_input[i]` / `layers_output[i]` - Layer I/O
 - `attentions[i]` / `attentions_input[i]` / `attentions_output[i]` - Attention modules
 - `mlps[i]` / `mlps_input[i]` / `mlps_output[i]` - MLP modules
+- `attentions_output[i]` / `mlps_output[i]` never include the residual stream. Architectures that add the residual inside the sublayer module (BLOOM, MPT, DBRX) have their output accessors remapped to the pre-residual submodule via `rename_utils.RESIDUAL_INSIDE_SUBLAYER_SOURCES` (issue #51); unknown architectures with a `residual` forward arg are rejected at load unless `RenameConfig(attn_output_source=.../mlp_output_source=...)` is passed. (Caveat: on Gemma-2/3-style models, a post-sublayer layernorm outside the module means the added contribution is the post-LN output, not the module output these accessors return.)
 - `token_embeddings` - Token embedding layer (read/write)
 - `logits` - Final model logits
 - `next_token_probs` - Softmax of last token logits
@@ -120,6 +121,7 @@ nnterp is a mechanistic interpretability library built on top of nnsight, provid
 - `get_rename_dict()` - Generate renaming dictionary for a model
 - `check_model_renaming()` - Validate module standardization after renaming
 - `allow_multimodal` param: controls whether heterogeneous layer types (e.g. self-attn + cross-attn) are accepted
+- `attn_output_source` / `mlp_output_source` params: dotted path (relative to a layer) to the module whose output is the sublayer's additive contribution, for architectures that add the residual inside the attention/MLP module
 - **Supported Architectures**: OPT, Mixtral, Bloom, GPT-2, Qwen2Moe, Dbrx, GPT-J, LLaMA, Llama-4, Qwen3, Qwen2, Gemma-3, GLM-4v, and many more via auto-renaming
 - Includes attention probability accessors for different architectures
 

--- a/docs/adding-model-support.rst
+++ b/docs/adding-model-support.rst
@@ -85,6 +85,29 @@ Provide multiple options for the same component:
        mlp_name=["ffn", "feed_forward", "mlp_block"]
    )
 
+Modules That Add the Residual Internally
+----------------------------------------
+
+Some architectures (BLOOM, MPT, DBRX) add the residual stream to the sublayer
+output *inside* the attention/MLP module, so the module output is a
+residual-stream state rather than the additive contribution
+(`issue #51 <https://github.com/ndif-team/nnterp/issues/51>`_). nnterp refuses to
+load an unknown architecture whose attention/MLP forward takes a
+``residual``-like argument. To add support, point the output accessors to the
+last pre-residual submodule:
+
+.. code-block:: python
+
+   rename_config = RenameConfig(
+       attn_output_source="self_attn.dense",     # BLOOM's attention output projection
+       mlp_output_source="mlp.dense_4h_to_h",    # BLOOM's MLP output projection
+   )
+
+Paths are relative to a layer and use standardized (post-renaming) names. If the
+module does not actually add the residual to its output, pass the default source
+(``attn_output_source="self_attn"`` / ``mlp_output_source="mlp"``) to keep the
+module output.
+
 Real Example: GPT-J Support
 ----------------------------
 

--- a/docs/basic-usage.rst
+++ b/docs/basic-usage.rst
@@ -89,18 +89,6 @@ Access layer inputs and outputs directly:
        attn_output = model.attentions_output[3]
        mlp_output = model.mlps_output[3]
 
-.. note::
-
-   ``attentions_output[i]`` and ``mlps_output[i]`` never include the residual
-   stream. On architectures that add the residual *inside* the attention/MLP
-   module (BLOOM, MPT, DBRX), they target the last pre-residual submodule instead
-   of the literal module output (see
-   `issue #51 <https://github.com/ndif-team/nnterp/issues/51>`_). Use
-   ``model.attentions[i].output`` / ``model.mlps[i].output`` if you want the raw
-   module output. On architectures with post-sublayer layernorms outside these
-   modules (e.g. Gemma-2/3), the tensor added to the residual stream is the
-   post-layernorm output, not the module output these accessors return.
-
 Skip Layers
 ~~~~~~~~~~~
 

--- a/docs/basic-usage.rst
+++ b/docs/basic-usage.rst
@@ -89,6 +89,18 @@ Access layer inputs and outputs directly:
        attn_output = model.attentions_output[3]
        mlp_output = model.mlps_output[3]
 
+.. note::
+
+   ``attentions_output[i]`` and ``mlps_output[i]`` never include the residual
+   stream. On architectures that add the residual *inside* the attention/MLP
+   module (BLOOM, MPT, DBRX), they target the last pre-residual submodule instead
+   of the literal module output (see
+   `issue #51 <https://github.com/ndif-team/nnterp/issues/51>`_). Use
+   ``model.attentions[i].output`` / ``model.mlps[i].output`` if you want the raw
+   module output. On architectures with post-sublayer layernorms outside these
+   modules (e.g. Gemma-2/3), the tensor added to the residual stream is the
+   post-layernorm output, not the module output these accessors return.
+
 Skip Layers
 ~~~~~~~~~~~
 

--- a/docs/model-validation.rst
+++ b/docs/model-validation.rst
@@ -35,6 +35,7 @@ What ``nnterp`` Guarantees
 - All models follow the standardized naming convention
 - ``model.layers_output[i]`` returns tensors with expected shapes
 - ``model.attention_probabilities[i]`` (if enabled) returns properly normalized attention matrices
+- ``model.attentions_output[i]`` / ``model.mlps_output[i]`` never include the residual stream. Architectures that add it inside the attention/MLP module (BLOOM, MPT, DBRX) are remapped to the pre-residual submodule, unknown ones are rejected at load (see :doc:`adding-model-support`)
 
 What ``nnterp`` Cannot Guarantee
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -42,6 +43,7 @@ What ``nnterp`` Cannot Guarantee
 ``nnterp`` cannot guarantee:
 
 - **Attention probabilities remain unmodified**: The model might apply additional transformations after the attention probabilities are computed but before they're used. Check ``model.attention_probabilities.print_source()`` to understand the exact hook location in the HuggingFace implementation.
+- **Sublayer outputs are the exact residual contribution**: on architectures with post-sublayer layernorms outside the attention/MLP module (e.g. Gemma-2/3), the tensor added to the residual stream is the post-layernorm output, not ``attentions_output[i]`` / ``mlps_output[i]``. See `issue #53 <https://github.com/ndif-team/nnterp/issues/53>`_.
 - **Perfect HuggingFace compatibility**: While ``nnterp`` uses original HuggingFace implementations, some edge cases might behave differently due to the renaming process.
 
 .. code-block:: python

--- a/nnterp/nnsight_utils.py
+++ b/nnterp/nnsight_utils.py
@@ -11,7 +11,7 @@ from nnsight.intervention.tracing.globals import Object
 from transformers import PreTrainedModel
 
 from .utils import TraceTensor, unpack_tuple
-from .standardized_transformer import StandardizedTransformer
+from .standardized_transformer import StandardizationMixin, StandardizedTransformer
 from .rename_utils import get_rename_dict, RenameConfig
 
 GetModuleOutput = Callable[[LanguageModel, int], TraceTensor]
@@ -102,6 +102,10 @@ def get_attention_output(nn_model: LanguageModel, layer: int) -> TraceTensor:
     Returns:
         The Proxy for the output of the attention block of the layer
     """
+    if isinstance(nn_model, StandardizationMixin):
+        # Follows the standardized output source, which can differ from the module
+        # output on architectures that add the residual inside the module (issue #51)
+        return nn_model.attentions_output[layer]
     return unpack_tuple(get_attention(nn_model, layer).output)
 
 
@@ -116,6 +120,8 @@ def get_mlp_output(nn_model: LanguageModel, layer: int) -> TraceTensor:
     """
     Get the output of the MLP of a layer
     """
+    if isinstance(nn_model, StandardizationMixin):
+        return nn_model.mlps_output[layer]
     return unpack_tuple(get_mlp(nn_model, layer).output)
 
 

--- a/nnterp/rename_utils.py
+++ b/nnterp/rename_utils.py
@@ -1,3 +1,4 @@
+import inspect
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
 from typing import Literal
@@ -23,6 +24,7 @@ from .utils import (
     DbrxForCausalLM,
     StableLmForCausalLM,
     GptOssForCausalLM,
+    MptForCausalLM,
 )
 
 IgnoreType = Literal["mlp", "attention"]
@@ -103,6 +105,20 @@ class RenameConfig:
         or the vocab size directly. Defaults to standard keys:
         ['vocab_size', 'n_vocab', 'text_config.vocab_size'].
 
+    attn_output_source : str, optional
+        Dotted path (relative to a layer, using standardized names) to the module
+        whose output is the attention's additive contribution to the residual stream,
+        e.g. "self_attn.dense" for BLOOM. Needed for architectures that add the
+        residual *inside* the attention module, where the module output is already
+        a residual-stream state (see https://github.com/ndif-team/nnterp/issues/51).
+        ``attentions_output[i]`` reads/writes this module's output. Passing the
+        default "self_attn" explicitly asserts that the module output is the
+        additive contribution despite a ``residual``-like argument in its forward.
+
+    mlp_output_source : str, optional
+        Same as ``attn_output_source`` for the MLP, e.g. "mlp.dense_4h_to_h" for
+        BLOOM or "mlp.down_proj" for MPT.
+
     Example
     -------
     Custom configuration for a non-standard architecture::
@@ -126,6 +142,8 @@ class RenameConfig:
     attn_head_config_key: str | list[str] | int | None = None
     hidden_size_config_key: str | list[str] | int | None = None
     vocab_size_config_key: str | list[str] | int | None = None
+    attn_output_source: str | None = None
+    mlp_output_source: str | None = None
 
 
 MODEL_NAMES = ["transformer", "gpt_neox", "decoder", "language_model"]
@@ -159,8 +177,68 @@ def default_vocab_size_config_keys():
 # Models with no mlp module
 IGNORE_MLP_MODELS = (OPTForCausalLM,)
 
+# Architectures that add the residual stream to the sublayer output *inside* the
+# attention/MLP module, so the module output is a residual-stream state instead of
+# the additive contribution (https://github.com/ndif-team/nnterp/issues/51).
+# Maps model class -> (attn_output_source, mlp_output_source); None keeps the default.
+RESIDUAL_INSIDE_SUBLAYER_SOURCES = {
+    BloomForCausalLM: ("self_attn.dense", "mlp.dense_4h_to_h"),
+    MptForCausalLM: (None, "mlp.down_proj"),
+    # DbrxNormAttentionNorm returns (resid_mid, norm_2(resid_mid), attn_weights):
+    # its output[0] is a residual-stream state, the inner attn output is the contribution.
+    DbrxForCausalLM: ("self_attn.attn", None),
+}
+
+
+def bloom_slow_but_exact(model) -> bool:
+    """BLOOM checkpoints with pretraining_tp > 1 and slow_but_exact=True (e.g.
+    bigscience/bigscience-small-testing) compute the output projections with
+    F.linear, bypassing the dense modules, so no pre-residual module exists."""
+    return (
+        isinstance(model, BloomForCausalLM)
+        and model.config.pretraining_tp > 1
+        and model.config.slow_but_exact
+    )
+
+
+def get_output_sources(
+    model, rename_config: RenameConfig | None = None
+) -> tuple[str | None, str | None]:
+    """Resolve the module paths targeted by attentions_output / mlps_output.
+
+    Defaults to the attention/MLP modules themselves. For architectures that add
+    the residual inside the sublayer module (BLOOM, MPT), targets the last
+    pre-residual projection so the accessors expose the additive contribution.
+    Returns None for a sublayer whose contribution is not exposed by any module
+    (slow_but_exact BLOOM): the corresponding accessor is disabled.
+    """
+    attn_source, mlp_source = "self_attn", "mlp"
+    if bloom_slow_but_exact(model):
+        attn_source = mlp_source = None
+    else:
+        for model_class, (
+            attn_override,
+            mlp_override,
+        ) in RESIDUAL_INSIDE_SUBLAYER_SOURCES.items():
+            if isinstance(model, model_class):
+                attn_source = attn_override or attn_source
+                mlp_source = mlp_override or mlp_source
+    if rename_config is not None:
+        if rename_config.attn_output_source is not None:
+            attn_source = rename_config.attn_output_source
+        if rename_config.mlp_output_source is not None:
+            mlp_source = rename_config.mlp_output_source
+    return attn_source, mlp_source
+
+
 # Alternative names for LLM layers
-ATTENTION_NAMES = ["attn", "self_attention", "attention", "norm_attn_norm", "linear_attn"]
+ATTENTION_NAMES = [
+    "attn",
+    "self_attention",
+    "attention",
+    "norm_attn_norm",
+    "linear_attn",
+]
 LAYER_NAMES = expand_path_with_model(
     [
         "h",
@@ -313,24 +391,34 @@ class IOType(Enum):
 
 
 class LayerAccessor:
-    """I/O accessor that provides input/output access with setter"""
+    """I/O accessor that provides input/output access with setter.
+
+    If ``disabled_reason`` is set, any access raises a RenamingError with that
+    message (used when no module carries the accessor's semantics, e.g.
+    attentions_output on slow_but_exact BLOOM).
+    """
 
     def __init__(
         self,
         model,
         attr_name: str | None,
         io_type: IOType | None,
+        disabled_reason: str | None = None,
     ):
 
         self.model = model
         self.attr_name = attr_name
         self.io_type = io_type
+        self.disabled_reason = disabled_reason
         self._detected_is_tuple: bool | None = None
 
     def get_module(self, layer: int) -> Envoy:
+        if self.disabled_reason is not None:
+            raise RenamingError(self.disabled_reason)
         module = self.model.layers[layer]
         if self.attr_name is not None:
-            module = getattr(module, self.attr_name)
+            for attr in self.attr_name.split("."):
+                module = getattr(module, attr)
         return module
 
     def __getitem__(self, layer: int) -> TraceTensor | Envoy:
@@ -423,7 +511,9 @@ def gptj_attention_prob_source(attention_module, return_module_source: bool = Fa
         return attention_module.source.self__attn_0.source.self_attn_dropout_0
 
 
-def qwen2moe_attention_prob_source(attention_module, return_module_source: bool = False):
+def qwen2moe_attention_prob_source(
+    attention_module, return_module_source: bool = False
+):
     if return_module_source:
         return attention_module.source
     else:
@@ -437,7 +527,9 @@ def dbrx_attention_prob_source(attention_module, return_module_source: bool = Fa
         return attention_module.attn.source.nn_functional_dropout_0
 
 
-def stablelm_attention_prob_source(attention_module, return_module_source: bool = False):
+def stablelm_attention_prob_source(
+    attention_module, return_module_source: bool = False
+):
     if return_module_source:
         return attention_module.source
     else:
@@ -472,6 +564,9 @@ class AttentionProbabilitiesAccessor:
         elif isinstance(model._model, GPTJForCausalLM):
             self.source_attr = gptj_attention_prob_source
         elif isinstance(model._model, Qwen2MoeForCausalLM):
+            self.source_attr = qwen2moe_attention_prob_source
+        elif isinstance(model._model, MptForCausalLM):
+            # MptAttention: softmax then nn.functional.dropout, same as Qwen2Moe
             self.source_attr = qwen2moe_attention_prob_source
         elif isinstance(model._model, DbrxForCausalLM):
             self.source_attr = dbrx_attention_prob_source
@@ -547,9 +642,7 @@ class AttentionProbabilitiesAccessor:
                 sum_last = probs.sum(dim=-1)
                 if self.attn_probs_dont_sum_to_one:
                     if not (sum_last > 0).all():
-                        raise RenamingError(
-                            "Attention probabilities should be > 0."
-                        )
+                        raise RenamingError("Attention probabilities should be > 0.")
                     if not (sum_last < 1 + 1e-5).all():
                         raise RenamingError(
                             "Attention probabilities should sum to < 1 for models with sink tokens."
@@ -644,6 +737,15 @@ def get_ignores(model, rename_config: RenameConfig | None = None) -> list[str]:
             message += " You'll have to manually use layers.fc1 and layers.fc2 instead."
         logger.warning(message)
         ignores.append("mlp")
+    if bloom_slow_but_exact(model):
+        logger.warning(
+            f"{model.config.name_or_path} uses pretraining_tp > 1 with slow_but_exact=True, "
+            "which computes the attention/MLP output projections with F.linear instead of the "
+            "dense modules. No module exposes the sublayer contributions, so attentions_output "
+            "/ mlps_output are disabled and attention/MLP checks are skipped "
+            "(see https://github.com/ndif-team/nnterp/issues/51)."
+        )
+        ignores.extend(["attention", "mlp"])
     if rename_config is not None:
         if rename_config.ignore_mlp:
             ignores.append("mlp")
@@ -684,19 +786,54 @@ def check_io(std_model, model_name: str, ignores: list[IgnoreType]):
         )
     expected_hidden = (*input_size, hidden_size)
 
-    _check_tensor(std_model.token_embeddings, "token_embeddings", expected_hidden, model_name)
-    _check_tensor(std_model.layers_input[0], "layers_input[0]", expected_hidden, model_name)
+    _check_tensor(
+        std_model.token_embeddings, "token_embeddings", expected_hidden, model_name
+    )
+    _check_tensor(
+        std_model.layers_input[0], "layers_input[0]", expected_hidden, model_name
+    )
 
     if "attention" not in ignores:
-        _check_tensor(std_model.attentions_input[0], "attentions_input[0]", expected_hidden, model_name)
-        _check_tensor(std_model.attentions_output[0], "attentions_output[0]", expected_hidden, model_name)
+        _check_tensor(
+            std_model.attentions_input[0],
+            "attentions_input[0]",
+            expected_hidden,
+            model_name,
+        )
+        _check_tensor(
+            std_model.attentions_output[0],
+            "attentions_output[0]",
+            expected_hidden,
+            model_name,
+        )
 
     if "mlp" not in ignores:
-        _check_tensor(std_model.mlps_input[0], "mlps_input[0]", expected_hidden, model_name)
-        _check_tensor(std_model.mlps_output[0], "mlps_output[0]", expected_hidden, model_name)
+        _check_tensor(
+            std_model.mlps_input[0], "mlps_input[0]", expected_hidden, model_name
+        )
+        mlp_out = std_model.mlps_output[0]
+        _check_tensor(mlp_out, "mlps_output[0]", expected_hidden, model_name)
 
-    _check_tensor(std_model.layers_output[0], "layers_output[0]", expected_hidden, model_name)
-    _check_tensor(std_model.ln_final.output, "ln_final.output", expected_hidden, model_name)
+    layer_out = std_model.layers_output[0]
+    _check_tensor(layer_out, "layers_output[0]", expected_hidden, model_name)
+    # Value-based residual-semantics check (issue #51), only when the tensors hold
+    # real values (i.e. not during a scan on fake/meta tensors).
+    if (
+        "mlp" not in ignores
+        and layer_out.device != th.device("meta")
+        and th.allclose(mlp_out, layer_out)
+    ):
+        raise RenamingError(
+            f"mlps_output[0] is identical to layers_output[0] in {model_name} architecture. "
+            "This means the MLP module adds the residual stream to its output inside the module, "
+            "so mlps_output returns residual-stream states instead of the additive MLP "
+            "contribution (see https://github.com/ndif-team/nnterp/issues/51). Pass "
+            "RenameConfig(mlp_output_source='<path.to.submodule>') pointing to the submodule "
+            "whose output is the additive contribution (e.g. 'mlp.dense_4h_to_h' for BLOOM)."
+        )
+    _check_tensor(
+        std_model.ln_final.output, "ln_final.output", expected_hidden, model_name
+    )
 
     # vLLM computes logits in a separate phase (not part of the model forward pass),
     # so lm_head.output is not accessible during a vLLM trace.
@@ -744,12 +881,73 @@ def _warn_heterogeneous_types(accessor, num_layers: int, kind: str, model_name: 
         )
 
 
+def _check_output_source(
+    std_model,
+    kind: IgnoreType,
+    model_name: str,
+    rename_config: RenameConfig | None = None,
+):
+    """Check that attentions_output / mlps_output expose the additive sublayer
+    contribution, not a residual-added state (issue #51).
+
+    If the sublayer module takes a residual-like argument in its forward pass, it
+    most likely adds the residual to its output inside the module (BLOOM, MPT), so
+    an output source pointing to the pre-residual submodule must be configured.
+    An explicitly configured source (built-in or via RenameConfig) is trusted,
+    including an explicit default source (user asserts the module output is the
+    contribution).
+    """
+    if kind == "attention":
+        accessor, default_source, config_field = (
+            std_model.attentions_output,
+            "self_attn",
+            "attn_output_source",
+        )
+    else:
+        accessor, default_source, config_field = (
+            std_model.mlps_output,
+            "mlp",
+            "mlp_output_source",
+        )
+    try:
+        module = accessor.get_module(0)._module
+    except AttributeError as e:
+        raise RenamingError(
+            f"The configured {config_field}='{accessor.attr_name}' does not resolve to a module "
+            f"of layer 0 in {model_name} architecture."
+        ) from e
+    explicitly_configured = (
+        rename_config is not None and getattr(rename_config, config_field) is not None
+    )
+    if explicitly_configured or accessor.attr_name != default_source:
+        return
+    residual_params = [
+        name
+        for name in inspect.signature(module.forward).parameters
+        if "residual" in name
+    ]
+    if residual_params:
+        accessor_name = "attentions_output" if kind == "attention" else "mlps_output"
+        raise RenamingError(
+            f"The {kind} module ({type(module).__name__}) of {model_name} takes a "
+            f"`{residual_params[0]}` argument in its forward pass. This usually means the residual "
+            f"stream is added to the sublayer output inside the module, in which case "
+            f"{accessor_name} would return residual-stream states instead of the additive {kind} "
+            "contribution (see https://github.com/ndif-team/nnterp/issues/51).\n"
+            f"If so, pass RenameConfig({config_field}='<path.to.submodule>') pointing to the "
+            f"submodule whose output is the additive contribution (e.g. 'self_attn.dense' for "
+            f"BLOOM). If the module does not add the residual to its output, pass "
+            f"RenameConfig({config_field}='{default_source}') to keep the default behavior."
+        )
+
+
 def check_model_renaming(
     std_model,
     model_name: str,
     ignores: list[IgnoreType],
     allow_dispatch: bool,
     allow_multimodal: bool = False,
+    rename_config: RenameConfig | None = None,
 ):
     _check_has_module(std_model, "layers", model_name, "layers_rename")
 
@@ -770,11 +968,17 @@ def check_model_renaming(
 
     if "attention" not in ignores:
         _check_has_module(std_model.layers[0], "self_attn", model_name, "attn_rename")
-        _warn_heterogeneous_types(std_model.attentions, std_model.num_layers, "attention", model_name)
+        _warn_heterogeneous_types(
+            std_model.attentions, std_model.num_layers, "attention", model_name
+        )
+        _check_output_source(std_model, "attention", model_name, rename_config)
 
     if "mlp" not in ignores:
         _check_has_module(std_model.layers[0], "mlp", model_name, "mlp_rename")
-        _warn_heterogeneous_types(std_model.mlps, std_model.num_layers, "MLP", model_name)
+        _warn_heterogeneous_types(
+            std_model.mlps, std_model.num_layers, "MLP", model_name
+        )
+        _check_output_source(std_model, "mlp", model_name, rename_config)
 
     try_with_scan(
         std_model,

--- a/nnterp/standardized_transformer.py
+++ b/nnterp/standardized_transformer.py
@@ -22,6 +22,7 @@ from .rename_utils import (
     RenameConfig,
     get_rename_dict,
     get_ignores,
+    get_output_sources,
     check_model_renaming,
     get_num_attention_heads,
     get_hidden_size,
@@ -45,6 +46,14 @@ class StandardizationMixin:
     - attentions_input[i] / attentions_output[i]: Get/set attention input/output at layer i
     - mlps[i]: Get MLP module at layer i
     - mlps_input[i] / mlps_output[i]: Get/set MLP input/output at layer i
+
+    attentions_output[i] / mlps_output[i] never include the residual stream: on
+    architectures that add the residual inside the attention/MLP module (BLOOM,
+    MPT, DBRX), they target the last pre-residual submodule instead of the module
+    output (see issue #51). Note that on architectures with post-sublayer
+    layernorms outside these modules (e.g. Gemma-2/3), the tensor added to the
+    residual stream is the post-layernorm output, not the module output returned
+    here.
 
     Args:
         model (str or Module): Hugging Face repository ID or path of the model to load or loaded model.
@@ -90,15 +99,39 @@ class StandardizationMixin:
 
         ignores = get_ignores(self._model, rename_config)
 
-        # Create accessor instances
+        # Create accessor instances. attentions_output / mlps_output may target a
+        # submodule on architectures that add the residual inside the sublayer
+        # module (see rename_utils.RESIDUAL_INSIDE_SUBLAYER_SOURCES and issue #51),
+        # and are disabled (None source) when no module carries the contribution.
+        attn_output_source, mlp_output_source = get_output_sources(
+            self._model, rename_config
+        )
+
+        def output_accessor(source: str | None, name: str, default: str):
+            if source is not None:
+                return LayerAccessor(self, source, IOType.OUTPUT)
+            return LayerAccessor(
+                self,
+                default,
+                IOType.OUTPUT,
+                disabled_reason=(
+                    f"{name} is disabled for this model: no module exposes the sublayer's "
+                    "additive contribution to the residual stream (see the warning logged at "
+                    "load and https://github.com/ndif-team/nnterp/issues/51). Use "
+                    f"layers[i].{default}.output for the raw (residual-added) module output."
+                ),
+            )
+
         self.layers_input = LayerAccessor(self, None, IOType.INPUT)
         self.layers_output = LayerAccessor(self, None, IOType.OUTPUT)
         self.attentions = LayerAccessor(self, "self_attn", None)
         self.attentions_input = LayerAccessor(self, "self_attn", IOType.INPUT)
-        self.attentions_output = LayerAccessor(self, "self_attn", IOType.OUTPUT)
+        self.attentions_output = output_accessor(
+            attn_output_source, "attentions_output", "self_attn"
+        )
         self.mlps = LayerAccessor(self, "mlp", None)
         self.mlps_input = LayerAccessor(self, "mlp", IOType.INPUT)
-        self.mlps_output = LayerAccessor(self, "mlp", IOType.OUTPUT)
+        self.mlps_output = output_accessor(mlp_output_source, "mlps_output", "mlp")
 
         self.num_layers = len(self.layers)
         self.num_heads = get_num_attention_heads(
@@ -113,7 +146,12 @@ class StandardizationMixin:
 
         if check_renaming:
             check_model_renaming(
-                self, model_name, ignores, allow_dispatch, allow_multimodal
+                self,
+                model_name,
+                ignores,
+                allow_dispatch,
+                allow_multimodal,
+                rename_config=rename_config,
             )
         self.attention_probabilities = AttentionProbabilitiesAccessor(
             self,
@@ -325,14 +363,20 @@ class StandardizationMixin:
             layers = [layers]
         for layer in sorted(layers):  # sort to ensure execution order
             layer_output = self.layers_output[layer]
-            steering_with = factor * steering_vector.to(device=layer_output.device, dtype=layer_output.dtype)
+            steering_with = factor * steering_vector.to(
+                device=layer_output.device, dtype=layer_output.dtype
+            )
             if self.is_vllm:
                 # vLLM inference tensors don't support inplace ops
                 if batch_index is None and token_positions is None:
-                    self.layers_output[layer] = self.layers_output[layer] + steering_with
+                    self.layers_output[layer] = (
+                        self.layers_output[layer] + steering_with
+                    )
                 elif batch_index is not None and token_positions is not None:
                     out = self.layers_output[layer].clone()
-                    out[batch_index, token_positions] = out[batch_index, token_positions] + steering_with
+                    out[batch_index, token_positions] = (
+                        out[batch_index, token_positions] + steering_with
+                    )
                     self.layers_output[layer] = out
                 elif token_positions is not None:
                     out = self.layers_output[layer].clone()
@@ -346,7 +390,9 @@ class StandardizationMixin:
                 if batch_index is None and token_positions is None:
                     self.layers_output[layer] += steering_with
                 elif batch_index is not None and token_positions is not None:
-                    self.layers_output[layer][batch_index, token_positions] += steering_with
+                    self.layers_output[layer][
+                        batch_index, token_positions
+                    ] += steering_with
                 elif token_positions is not None:
                     self.layers_output[layer][:, token_positions] += steering_with
                 else:
@@ -445,6 +491,14 @@ class StandardizedTransformer(LanguageModel, StandardizationMixin):
     - attentions_input[i] / attentions_output[i]: Get/set attention input/output at layer i
     - mlps[i]: Get MLP module at layer i
     - mlps_input[i] / mlps_output[i]: Get/set MLP input/output at layer i
+
+    attentions_output[i] / mlps_output[i] never include the residual stream: on
+    architectures that add the residual inside the attention/MLP module (BLOOM,
+    MPT, DBRX), they target the last pre-residual submodule instead of the module
+    output (see issue #51). Note that on architectures with post-sublayer
+    layernorms outside these modules (e.g. Gemma-2/3), the tensor added to the
+    residual stream is the post-layernorm output, not the module output returned
+    here.
 
     Args:
         model (str or Module): Hugging Face repository ID or path of the model to load or loaded model.

--- a/nnterp/tests/test_model_renaming.py
+++ b/nnterp/tests/test_model_renaming.py
@@ -14,7 +14,7 @@ from nnterp.nnsight_utils import (
     get_num_layers,
     ModuleAccessor,
 )
-from nnterp.rename_utils import get_ignores, RenameConfig
+from nnterp.rename_utils import get_ignores, RenameConfig, RenamingError
 from transformers import OPTForCausalLM
 import torch.nn as nn
 
@@ -182,11 +182,24 @@ def test_standardized_transformer_methods(model_name):
             if "mlp" not in ignores:
                 assert model.mlps[0] is not None
                 assert model.layers[0].mlp is not None
-            attn_output_accessor = model.attentions_output[0].save()
-            attn_output_direct = model.model.layers[0].self_attn.output[0].save()
+            # On architectures that add the residual inside the sublayer module
+            # (BLOOM, MPT, DBRX), the output accessors target a submodule, so the
+            # direct access follows the accessor's attr_name path (issue #51).
+            if "attention" not in ignores:
+                attn_output_accessor = model.attentions_output[0].save()
+                attn_output_direct = model.model.layers[0]
+                for attr in model.attentions_output.attr_name.split("."):
+                    attn_output_direct = getattr(attn_output_direct, attr)
+                attn_output_direct = attn_output_direct.output
+                if isinstance(attn_output_direct, tuple):
+                    attn_output_direct = attn_output_direct[0]
+                attn_output_direct = attn_output_direct.save()
             if "mlp" not in ignores:
                 mlps_output_accessor = model.mlps_output[0].save()
-                mlps_output_direct = model.model.layers[0].mlp.output
+                mlps_output_direct = model.model.layers[0]
+                for attr in model.mlps_output.attr_name.split("."):
+                    mlps_output_direct = getattr(mlps_output_direct, attr)
+                mlps_output_direct = mlps_output_direct.output
                 if isinstance(mlps_output_direct, tuple):
                     mlps_output_direct = mlps_output_direct[0]
                 mlps_output_direct = mlps_output_direct.save()
@@ -207,9 +220,10 @@ def test_standardized_transformer_methods(model_name):
         assert th.allclose(
             layer_input_accessor, layer_input_direct
         ), "Layer input mismatch between accessor and direct access"
-        assert th.allclose(
-            attn_output_accessor, attn_output_direct
-        ), "Attention output mismatch between accessor and direct access"
+        if "attention" not in ignores:
+            assert th.allclose(
+                attn_output_accessor, attn_output_direct
+            ), "Attention output mismatch between accessor and direct access"
         if "mlp" not in ignores:
             assert th.allclose(
                 mlps_output_accessor, mlps_output_direct
@@ -229,7 +243,8 @@ def test_standardized_transformer_methods(model_name):
         assert next_probs.shape == (logits.shape[0], logits.shape[2])
         if "mlp" not in ignores:
             assert mlps_output_accessor.shape == layer_output_accessor.shape
-        assert attn_output_accessor.shape == layer_input_accessor.shape
+        if "attention" not in ignores:
+            assert attn_output_accessor.shape == layer_input_accessor.shape
 
 
 def test_renamed_model_methods(model_name):
@@ -251,7 +266,8 @@ def test_renamed_model_methods(model_name):
 
             # Test layer 0 methods
             layer_input = get_layer_input(model, 0).save()
-            attn_output = get_attention_output(model, 0).save()
+            if "attention" not in ignores:
+                attn_output = get_attention_output(model, 0).save()
             if "mlp" not in ignores:
                 mlps_output = get_mlp_output(model, 0)
                 if isinstance(mlps_output, tuple):
@@ -279,7 +295,8 @@ def test_renamed_model_methods(model_name):
         assert logits_output.shape == (batch_size, seq_len, model.vocab_size)
         if "mlp" not in ignores:
             assert mlps_output.shape == (batch_size, seq_len, model.hidden_size)
-        assert attn_output.shape == (batch_size, seq_len, model.hidden_size)
+        if "attention" not in ignores:
+            assert attn_output.shape == (batch_size, seq_len, model.hidden_size)
 
 
 def test_standardized_transformer_input_accessors(model_name):
@@ -721,3 +738,105 @@ def test_module_accessor(model_name, raw_model):
             layers_attr = accessor.layers
             assert isinstance(layers_attr, nn.ModuleList)
             assert len(layers_attr) == len(layers)
+
+
+# Architectures that add the residual inside the attention/MLP module (issue #51).
+RESIDUAL_INSIDE_MODELS = [
+    "yujiepan/bloom-tiny-random",
+    "hf-internal-testing/tiny-random-MptForCausalLM",
+    "yujiepan/dbrx-tiny-random",
+]
+
+
+@pytest.mark.parametrize("residual_model_name", RESIDUAL_INSIDE_MODELS)
+def test_sublayer_output_contribution_semantics(residual_model_name):
+    """attentions_output / mlps_output expose additive contributions, not
+    residual-added states, on architectures that add the residual inside the
+    sublayer module (issue #51)."""
+    with th.no_grad():
+        model = StandardizedTransformer(residual_model_name)
+        prompt = "Hello, world!"
+        with model.trace(prompt):
+            layer_in = model.layers_input[0].save()
+            attn_out = model.attentions_output[0].save()
+            mlp_out = model.mlps_output[0].save()
+            layer_out = model.layers_output[0].save()
+
+        # The buggy behavior returned residual-stream states here
+        assert not th.allclose(mlp_out, layer_out)
+        assert not th.allclose(attn_out, layer_in)
+        # Pre-LN additivity: the contributions sum to the residual stream delta
+        assert th.allclose(layer_in + attn_out + mlp_out, layer_out, atol=1e-5)
+
+        # Setting the attention contribution to zero removes it from the stream
+        with model.trace(prompt):
+            layer_in_ablated = model.layers_input[0].save()
+            model.attentions_output[0] = th.zeros_like(model.attentions_output[0])
+            mlp_out_ablated = model.mlps_output[0].save()
+            layer_out_ablated = model.layers_output[0].save()
+
+        assert not th.allclose(layer_out_ablated, layer_out)
+        assert th.allclose(
+            layer_in_ablated + mlp_out_ablated, layer_out_ablated, atol=1e-5
+        )
+
+
+def test_residual_inside_module_detection(monkeypatch):
+    """Without a configured output source, loading an architecture whose sublayer
+    modules take a residual argument raises a RenamingError (issue #51)."""
+    from nnterp import rename_utils
+    from nnterp.rename_utils import RenamingError
+
+    monkeypatch.setattr(rename_utils, "RESIDUAL_INSIDE_SUBLAYER_SOURCES", {})
+    with pytest.raises(RenamingError, match="residual"):
+        StandardizedTransformer("yujiepan/bloom-tiny-random")
+
+
+def test_residual_inside_module_user_config(monkeypatch):
+    """RenameConfig output sources configure contribution semantics for
+    architectures without built-in support, and explicitly passing the default
+    source opts out of the residual-argument detection (issue #51)."""
+    from nnterp import rename_utils
+
+    monkeypatch.setattr(rename_utils, "RESIDUAL_INSIDE_SUBLAYER_SOURCES", {})
+    model = StandardizedTransformer(
+        "yujiepan/bloom-tiny-random",
+        rename_config=RenameConfig(
+            attn_output_source="self_attn.dense",
+            mlp_output_source="mlp.dense_4h_to_h",
+        ),
+    )
+    with th.no_grad():
+        with model.trace("Hello, world!"):
+            layer_in = model.layers_input[0].save()
+            attn_out = model.attentions_output[0].save()
+            mlp_out = model.mlps_output[0].save()
+            layer_out = model.layers_output[0].save()
+    assert th.allclose(layer_in + attn_out + mlp_out, layer_out, atol=1e-5)
+
+    # Explicit default source = user asserts the module output is the contribution
+    StandardizedTransformer(
+        "yujiepan/bloom-tiny-random",
+        rename_config=RenameConfig(
+            attn_output_source="self_attn", mlp_output_source="mlp"
+        ),
+    )
+
+
+def test_slow_but_exact_bloom_disables_output_accessors():
+    """BLOOM checkpoints with pretraining_tp > 1 and slow_but_exact=True compute the
+    output projections with F.linear, so no module carries the sublayer
+    contributions: attentions_output / mlps_output are disabled (issue #51)."""
+    model = StandardizedTransformer("bigscience/bigscience-small-testing")
+    ignores = get_ignores(model._model)
+    assert "attention" in ignores and "mlp" in ignores
+    with pytest.raises(RenamingError, match="disabled"):
+        model.attentions_output[0]
+    with pytest.raises(RenamingError, match="disabled"):
+        model.mlps_output[0]
+    # Module and input accessors still work, and tracing is unaffected
+    with th.no_grad(), model.trace("Hello, world!"):
+        attn_in = model.attentions_input[0].save()
+        logits = model.logits.save()
+    assert attn_in.shape[-1] == model.hidden_size
+    assert logits.shape[-1] == model.vocab_size

--- a/nnterp/utils.py
+++ b/nnterp/utils.py
@@ -74,6 +74,11 @@ try:
 except ImportError:
     GptOssForCausalLM = ArchitectureNotFound
 
+try:
+    from transformers import MptForCausalLM
+except ImportError:
+    MptForCausalLM = ArchitectureNotFound
+
 
 def detect_automodel(
     model: str,
@@ -154,7 +159,10 @@ class DummyCache:
 
 
 def dummy_inputs():
-    return {"input_ids": th.tensor([[0, 1, 1]]), "attention_mask": th.tensor([[1, 1, 1]])}
+    return {
+        "input_ids": th.tensor([[0, 1, 1]]),
+        "attention_mask": th.tensor([[1, 1, 1]]),
+    }
 
 
 def try_with_scan(


### PR DESCRIPTION
Fixes #51.

## Problem

On architectures that add the residual stream *inside* the attention/MLP module, `attentions_output[i]` / `mlps_output[i]` returned residual-stream states (`resid_mid` / `resid_post`) instead of the sublayer's additive contribution — same shape, same dtype, wrong tensor. Affected in transformers 4.56:

| Architecture | attention side | MLP side |
|---|---|---|
| BLOOM | `BloomAttention` adds `residual` internally | `BloomMLP` adds `residual` internally |
| MPT | fine | `MptMLP.forward(hidden_states, residual)` returns `output + residual` |
| DBRX | `DbrxNormAttentionNorm.output[0]` is `resid_mid` (no `residual` arg!) | fine |

## Fix

- `attentions_output` / `mlps_output` now target the last pre-residual submodule on those architectures (`rename_utils.RESIDUAL_INSIDE_SUBLAYER_SOURCES`: BLOOM → `self_attn.dense` / `mlp.dense_4h_to_h`, MPT → `mlp.down_proj`, DBRX → `self_attn.attn`), via dotted-path support in `LayerAccessor`. Writes land before the residual add, so interventions stay causal. Raw module output remains available via `attentions[i].output` / `mlps[i].output`.
- `RenameConfig(attn_output_source=..., mlp_output_source=...)` for architectures without built-in support; passing the default source explicitly opts out of detection.
- **Detection for unknown architectures** at load: refuse with instructions when the sublayer forward takes a `residual`-like argument (structural, runs under `scan()`), and when `mlps_output[0]` is identical to `layers_output[0]` (exact value check, runs whenever real values exist). Cosine-similarity detection was evaluated and rejected: residual-included outputs give cos = 1.0 exactly, but standard models reach 0.96 at layer 0 (TinyLLama), so any threshold is fragile.
- `slow_but_exact` BLOOM with `pretraining_tp > 1` (e.g. `bigscience/bigscience-small-testing`) computes the projections with `F.linear`, bypassing the modules entirely: attention/MLP are added to `ignores` (warning at load, like OPT's MLP) and the output accessors are disabled with an explanatory error.
- `nnsight_utils.get_attention_output` / `get_mlp_output` route through the standardized accessors for standardized models; MPT attention-probability support added.
- Docs: `basic-usage.rst` note on output semantics, `adding-model-support.rst` section on `*_output_source`, CLAUDE.md.

## Verification

- New tests: contribution additivity `layers_output == layers_input + attentions_output + mlps_output` (exact, 0.0 error) and zero-ablation semantics on tiny BLOOM/MPT/DBRX; detection raises on BLOOM with the registry cleared; user config and opt-out paths; `slow_but_exact` disable.
- Regression sweep (`test_model_renaming`, `test_nnsight_utils`, `test_interventions`, `test_probabilities` × bloom-tiny, dbrx-tiny, tiny-random-Mpt, gpt2, TinyLLama, bigscience-small-testing, opt-tiny): **183 passed, 0 failed**.
- Audit of all 64 working zoo models: no other architecture shows the bug signature; no load regressions (the only failures are pre-existing env issues: missing `einops`/`timm`/tokenizer deps, multimodal rejection).

## Known limitations / follow-ups

- Architectures with post-sublayer layernorms outside the module (Gemma-2/3, GLM-4): the added contribution is `post_ln(module_out)`; the accessors return the module output (never residual-added, but not the composed contribution). Documented; a separate design decision (cf. interp-engine's `attn_out` vs `attn_out_post`).
- Sublayer output multipliers (Granite `residual_multiplier`, Falcon-H1 `attention_out_multiplier`) scale the contribution and are not accounted for.
- DBRX `attentions_input` is pre-LN (input to `norm_attn_norm`), unlike other architectures.

---
Investigated and implemented by Claude (Fable 5) via Claude Code, supervised by @Butanium.
Co-Authored-By: Claude <noreply@anthropic.com>

https://claude.ai/code/session_01WsVoqZQER5R3D6Sf7SCZHB
