### PR TITLE
Add text_only=True to load only the text tower of dual-registered multimodal checkpoints

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -53,8 +53,8 @@ nnterp is a mechanistic interpretability library built on top of nnsight, provid
 **nnsight** `nnterp` is built on top of `nnsight`. A very important thing about `nnsight` is that interventions in a trace **MUST BE WRITTEN IN ORDER**. This means e.g. you can't access the output of a layer and then access its input / its mlp output.
 
 **Model Loading** (`__init__.py`)
-- `load_model(model_name)` — **Recommended entrypoint**. Auto-detects VLMs via `detect_automodel()` and returns the appropriate wrapper (`StandardizedTransformer`, `StandardizedVLM`, or `StandardizedVLLM`)
-- `detect_automodel(model_name)` — Inspects model config to determine the right `AutoModel` class. Priority: `AutoModelForImageTextToText` > `AutoModelForCausalLM` > `AutoModelForSeq2SeqLM`
+- `load_model(model_name)` — **Recommended entrypoint**. Auto-detects VLMs via `detect_automodel()` and returns the appropriate wrapper (`StandardizedTransformer`, `StandardizedVLM`, or `StandardizedVLLM`). `text_only=True` loads only the text tower of multimodal checkpoints that register a separate causal-LM class (Mllama, Llama-4, Qwen3.5)
+- `detect_automodel(model_name)` — Inspects model config to determine the right `AutoModel` class. Priority: `AutoModelForImageTextToText` > `AutoModelForCausalLM` > `AutoModelForSeq2SeqLM`. With `text_only=True`, returns a marker subclass of `AutoModelForCausalLM` for dual-registered configs (needed so nnsight 0.7's multimodal guard stands down; drop with the nnsight 0.8 migration)
 
 **StandardizedTransformer** (`standardized_transformer.py`)
 - Unified interface for text transformer architectures (extends `nnsight.LanguageModel`)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -54,7 +54,7 @@ nnterp is a mechanistic interpretability library built on top of nnsight, provid
 
 **Model Loading** (`__init__.py`)
 - `load_model(model_name)` — **Recommended entrypoint**. Auto-detects VLMs via `detect_automodel()` and returns the appropriate wrapper (`StandardizedTransformer`, `StandardizedVLM`, or `StandardizedVLLM`). `text_only=True` loads only the text tower of multimodal checkpoints that register a separate causal-LM class (Mllama, Llama-4, Qwen3.5)
-- `detect_automodel(model_name)` — Inspects model config to determine the right `AutoModel` class. Priority: `AutoModelForImageTextToText` > `AutoModelForCausalLM` > `AutoModelForSeq2SeqLM`. With `text_only=True`, returns a marker subclass of `AutoModelForCausalLM` for dual-registered configs (needed so nnsight 0.7's multimodal guard stands down; drop with the nnsight 0.8 migration)
+- `detect_automodel(model_name)` — Inspects model config to determine the right `AutoModel` class. Priority: `AutoModelForImageTextToText` > `AutoModelForCausalLM` > `AutoModelForSeq2SeqLM`. With `text_only=True`, returns `AutoModelForCausalLM` for configs that register a separate, buildable text-only class
 
 **StandardizedTransformer** (`standardized_transformer.py`)
 - Unified interface for text transformer architectures (extends `nnsight.LanguageModel`)

--- a/docs/basic-usage.rst
+++ b/docs/basic-usage.rst
@@ -46,6 +46,9 @@ Or use ``load_model()`` which auto-detects the model type:
 
    model = load_model("gpt2")  # returns StandardizedTransformer
    vlm = load_model("Qwen/Qwen2-VL-2B-Instruct")  # returns StandardizedVLM
+   # Only the text tower of a multimodal checkpoint that ships a separate one
+   # (e.g. Llama-4, Mllama): no vision weights, returns StandardizedTransformer
+   text_model = load_model("meta-llama/Llama-3.2-11B-Vision", text_only=True)
 
 Vision-Language Models
 ~~~~~~~~~~~~~~~~~~~~~~

--- a/nnterp/__init__.py
+++ b/nnterp/__init__.py
@@ -22,6 +22,7 @@ def load_model(
     model: str,
     use_vllm: bool = False,
     allow_experimental_vllm: bool = False,
+    text_only: bool = False,
     **model_kwargs,
 ) -> Union[StandardizedTransformer, "StandardizedVLLM", StandardizedVLM]:
     """Load a model using the appropriate wrapper.
@@ -35,6 +36,10 @@ def load_model(
         allow_experimental_vllm: Acknowledge that the vLLM backend is experimental.
             Required when ``use_vllm=True``. Can also be enabled by setting the
             ``NNTERP_ALLOW_EXPERIMENTAL_VLLM=1`` environment variable.
+        text_only: If True and the checkpoint registers a separate text-only causal LM
+            class next to its multimodal one (e.g. Mllama, Llama-4, Qwen3.5), load only
+            that text tower as a ``StandardizedTransformer`` (no vision weights).
+            No effect otherwise. See ``detect_automodel``.
         **model_kwargs: Keyword arguments to pass to the model wrapper.
 
     Returns:
@@ -52,8 +57,10 @@ def load_model(
     automodel_cls = detect_automodel(
         model,
         trust_remote_code=model_kwargs.get("trust_remote_code", False),
+        text_only=text_only,
     )
     if automodel_cls is AutoModelForImageTextToText:
         return StandardizedVLM(model, **model_kwargs)
 
+    model_kwargs.setdefault("automodel", automodel_cls)
     return StandardizedTransformer(model, **model_kwargs)

--- a/nnterp/standardized_transformer.py
+++ b/nnterp/standardized_transformer.py
@@ -513,6 +513,10 @@ class StandardizedTransformer(LanguageModel, StandardizationMixin):
             tracing by setting attn_implementation="eager". Defaults to False.
         check_attn_probs_with_trace (bool, default True): If True, the model will be dispatched and a test will ensure that the attention probabilities returned sum to 1.
         rename_config (RenameConfig, default None): A RenameConfig object to use for renaming the model. If None, a default RenameConfig will be used.
+        text_only (bool, default False): If True and the checkpoint registers a separate text-only
+            causal LM class next to its multimodal one (e.g. Mllama, Llama-4, Qwen3.5), load only that
+            text tower (no vision weights). No effect on text models or on multimodal checkpoints
+            without a separate text-only class. See ``detect_automodel``.
     """
 
     is_vllm: bool = False
@@ -527,6 +531,7 @@ class StandardizedTransformer(LanguageModel, StandardizationMixin):
         check_attn_probs_with_trace: bool = True,
         rename_config: RenameConfig | None = None,
         automodel=None,
+        text_only: bool = False,
         **kwargs,
     ):
         # Detect VLMs and warn
@@ -535,7 +540,9 @@ class StandardizedTransformer(LanguageModel, StandardizationMixin):
             from transformers import AutoModelForImageTextToText
 
             automodel = detect_automodel(
-                model, trust_remote_code=kwargs.get("trust_remote_code", False)
+                model,
+                trust_remote_code=kwargs.get("trust_remote_code", False),
+                text_only=text_only,
             )
             if automodel is AutoModelForImageTextToText:
                 warnings.warn(

--- a/nnterp/tests/test_detect_automodel.py
+++ b/nnterp/tests/test_detect_automodel.py
@@ -22,3 +22,48 @@ def test_detect_automodel_vlm():
 def test_detect_automodel_seq2seq():
     """Seq2Seq model should get AutoModelForSeq2SeqLM."""
     assert detect_automodel("google-t5/t5-small") is AutoModelForSeq2SeqLM
+
+
+import pytest
+from transformers import MllamaForCausalLM
+
+from nnterp import StandardizedTransformer, load_model
+
+# Mllama registers MllamaForCausalLM next to MllamaForConditionalGeneration
+MLLAMA_TINY = "yujiepan/llama-3.2-vision-tiny-random"
+
+
+def test_detect_automodel_text_only_selects_text_tower():
+    assert detect_automodel(MLLAMA_TINY) is AutoModelForImageTextToText
+    cls = detect_automodel(MLLAMA_TINY, text_only=True)
+    # A marker subclass so nnsight 0.7's multimodal guard stands down; same dispatch
+    assert cls is not AutoModelForCausalLM
+    assert issubclass(cls, AutoModelForCausalLM)
+    assert cls._model_mapping is AutoModelForCausalLM._model_mapping
+
+
+def test_detect_automodel_text_only_without_separate_text_class():
+    """gemma3 maps to Gemma3ForConditionalGeneration in both auto tables."""
+    assert (
+        detect_automodel("yujiepan/gemma-3-tiny-random", text_only=True)
+        is AutoModelForImageTextToText
+    )
+
+
+def test_detect_automodel_text_only_unbuildable_text_tower_raises():
+    """Llama4ForCausalLM cannot be built from the composite Llama4Config in
+    transformers 4.56. If a newer transformers fixes that, this should start
+    returning a CausalLM subclass instead and the test needs updating."""
+    with pytest.raises(ValueError, match="text_only=True"):
+        detect_automodel("yujiepan/llama-4-tiny-random", text_only=True)
+
+
+def test_text_only_loads_text_tower():
+    # Mllama's text tower has cross-attention layers (heterogeneous), so skip renaming checks
+    model = load_model(MLLAMA_TINY, text_only=True, check_renaming=False)
+    assert isinstance(model, StandardizedTransformer)
+    assert isinstance(model._model, MllamaForCausalLM)
+    assert not hasattr(model._model, "vision_model")
+    with model.trace("Hello, world!"):
+        logits = model.logits.save()
+    assert logits.shape[-1] == model.vocab_size

--- a/nnterp/tests/test_detect_automodel.py
+++ b/nnterp/tests/test_detect_automodel.py
@@ -35,11 +35,7 @@ MLLAMA_TINY = "yujiepan/llama-3.2-vision-tiny-random"
 
 def test_detect_automodel_text_only_selects_text_tower():
     assert detect_automodel(MLLAMA_TINY) is AutoModelForImageTextToText
-    cls = detect_automodel(MLLAMA_TINY, text_only=True)
-    # A marker subclass so nnsight 0.7's multimodal guard stands down; same dispatch
-    assert cls is not AutoModelForCausalLM
-    assert issubclass(cls, AutoModelForCausalLM)
-    assert cls._model_mapping is AutoModelForCausalLM._model_mapping
+    assert detect_automodel(MLLAMA_TINY, text_only=True) is AutoModelForCausalLM
 
 
 def test_detect_automodel_text_only_without_separate_text_class():

--- a/nnterp/utils.py
+++ b/nnterp/utils.py
@@ -7,6 +7,7 @@ from .logging import logger
 import torch as th
 from nnsight.intervention.tracing.globals import Object
 import transformers
+from transformers import AutoModelForCausalLM
 import nnsight
 
 TraceTensor = Union[th.Tensor, Object]
@@ -80,9 +81,21 @@ except ImportError:
     MptForCausalLM = ArchitectureNotFound
 
 
+class TextOnlyAutoModelForCausalLM(AutoModelForCausalLM):
+    """``AutoModelForCausalLM`` as returned by ``detect_automodel(text_only=True)``.
+
+    Builds exactly what ``AutoModelForCausalLM`` builds (auto classes dispatch on
+    the inherited ``_model_mapping``). It is a distinct class because nnsight 0.7's
+    ``LanguageModel`` refuses configs registered with ``AutoModelForImageTextToText``
+    unless a non-default ``automodel`` is passed. To drop with the nnsight 0.8
+    migration, where ``task="text-generation"`` replaces ``automodel``.
+    """
+
+
 def detect_automodel(
     model: str,
     trust_remote_code: bool = False,
+    text_only: bool = False,
 ):
     """Detect the appropriate AutoModel class for a model by inspecting its config.
 
@@ -97,18 +110,55 @@ def detect_automodel(
     Args:
         model: HuggingFace model name or path.
         trust_remote_code: Whether to trust remote code when loading the config.
+        text_only: If True and the checkpoint registers a separate text-only causal
+            LM class next to its multimodal one (e.g. Mllama, Llama-4, Qwen3.5),
+            return that class so only the text tower is loaded. Raises if the
+            installed transformers cannot build it from the checkpoint's composite
+            config. No effect when there is no separate text-only class.
 
     Returns:
         The appropriate AutoModel class (e.g. ``AutoModelForCausalLM``).
     """
     from transformers import (
         AutoConfig,
-        AutoModelForCausalLM,
         AutoModelForImageTextToText,
         AutoModelForSeq2SeqLM,
     )
 
     config = AutoConfig.from_pretrained(model, trust_remote_code=trust_remote_code)
+    config_cls = type(config)
+
+    if (
+        text_only
+        and config_cls in AutoModelForImageTextToText._model_mapping
+        and config_cls in AutoModelForCausalLM._model_mapping
+    ):
+        text_cls = AutoModelForCausalLM._model_mapping[config_cls]
+        if text_cls is AutoModelForImageTextToText._model_mapping[config_cls]:
+            logger.info(
+                f"{model} has no separate text-only class ({text_cls.__name__} is "
+                "also its multimodal class), loading the multimodal model."
+            )
+        else:
+            # Not every architecture can build its text tower from the composite
+            # config (Llama4ForCausalLM reads vocab_size at the top level in 4.56).
+            with th.device("meta"):
+                try:
+                    AutoModelForCausalLM.from_config(
+                        config, trust_remote_code=trust_remote_code
+                    )
+                except Exception as e:
+                    raise ValueError(
+                        f"text_only=True but {text_cls.__name__} cannot be built from "
+                        f"the {config_cls.__name__} of {model} with transformers "
+                        f"{TRANSFORMERS_VERSION}: {e}\nLoad the full multimodal model "
+                        "instead (text_only=False or StandardizedVLM)."
+                    ) from e
+            logger.info(
+                f"Loading only the text tower ({text_cls.__name__}) of {model}, "
+                "the vision tower is not loaded."
+            )
+            return TextOnlyAutoModelForCausalLM
 
     candidates = [
         AutoModelForImageTextToText,
@@ -117,7 +167,7 @@ def detect_automodel(
     ]
 
     for cls in candidates:
-        if type(config) in cls._model_mapping:
+        if config_cls in cls._model_mapping:
             logger.info(
                 f"Auto-detected {cls.__name__} for {model} "
                 f"(config: {type(config).__name__})"

--- a/nnterp/utils.py
+++ b/nnterp/utils.py
@@ -81,17 +81,6 @@ except ImportError:
     MptForCausalLM = ArchitectureNotFound
 
 
-class TextOnlyAutoModelForCausalLM(AutoModelForCausalLM):
-    """``AutoModelForCausalLM`` as returned by ``detect_automodel(text_only=True)``.
-
-    Builds exactly what ``AutoModelForCausalLM`` builds (auto classes dispatch on
-    the inherited ``_model_mapping``). It is a distinct class because nnsight 0.7's
-    ``LanguageModel`` refuses configs registered with ``AutoModelForImageTextToText``
-    unless a non-default ``automodel`` is passed. To drop with the nnsight 0.8
-    migration, where ``task="text-generation"`` replaces ``automodel``.
-    """
-
-
 def detect_automodel(
     model: str,
     trust_remote_code: bool = False,
@@ -115,6 +104,9 @@ def detect_automodel(
             return that class so only the text tower is loaded. Raises if the
             installed transformers cannot build it from the checkpoint's composite
             config. No effect when there is no separate text-only class.
+            nnsight 0.7.0 refuses such configs in ``LanguageModel`` regardless of
+            the automodel's dispatch (over-broad multimodal guard, fixed upstream);
+            nnsight 0.6 and 0.8 (``task="text-generation"``) are unaffected.
 
     Returns:
         The appropriate AutoModel class (e.g. ``AutoModelForCausalLM``).
@@ -158,7 +150,7 @@ def detect_automodel(
                 f"Loading only the text tower ({text_cls.__name__}) of {model}, "
                 "the vision tower is not loaded."
             )
-            return TextOnlyAutoModelForCausalLM
+            return AutoModelForCausalLM
 
     candidates = [
         AutoModelForImageTextToText,


### PR DESCRIPTION
Adds `text_only=True` to `load_model()`, `StandardizedTransformer` and `detect_automodel()`: load only the text tower of a multimodal checkpoint that registers a separate text-only causal-LM class next to its multimodal one. Supersedes #52 with the same feature in ~50 lines inside the existing `detect_automodel` decision point (no new module, no second config read).

## What "dual-registered" actually means

Being in both auto tables is not enough. In transformers 4.56.2, 8 `model_type`s are in both `MODEL_FOR_IMAGE_TEXT_TO_TEXT_MAPPING_NAMES` and `MODEL_FOR_CAUSAL_LM_MAPPING_NAMES`, but only 3 have a *distinct* text class:

| model_type | CausalLM class | ImageTextToText class | separate text tower |
|---|---|---|---|
| `mllama` | `MllamaForCausalLM` | `MllamaForConditionalGeneration` | yes |
| `llama4` | `Llama4ForCausalLM` | `Llama4ForConditionalGeneration` | yes |
| `emu3` | `Emu3ForCausalLM` | `Emu3ForConditionalGeneration` | yes |
| `gemma3`, `gemma3n`, `fuyu`, `git`, `got_ocr2` | same class in both tables | | no |

And having a distinct class is still not enough: `Llama4ForCausalLM` cannot be built from the composite `Llama4Config` in 4.56.2 (`AttributeError: 'Llama4Config' object has no attribute 'vocab_size'` — the exact failure nnsight's guard exists for), while `MllamaForCausalLM` builds fine. (#52's `qwen3_5_moe` works because transformers 5.x resolves the nested text config.)

So `detect_automodel(text_only=True)`:
1. no separate text class → info log, load the multimodal class as before;
2. separate class → probe-build it on the meta device; if that fails, raise a `ValueError` naming the class, config and transformers version (instead of the raw HF error deep inside nnsight);
3. otherwise return `AutoModelForCausalLM`.

No marker subclass: nnsight 0.7.0's `LanguageModel._check_is_text_only` refuses any ImageTextToText-registered config when the automodel is the default `AutoModelForCausalLM`, so on that exact version `text_only=True` is refused for dual-registered checkpoints — the guard is over-broad and the fix belongs upstream (narrow it to configs with no causal-LM mapping; a 3-line change #52 already validated). nnsight 0.6 (nnterp's lock) has no guard, and 0.8 removes `automodel=` entirely in favor of `task="text-generation"`. Documented in the `detect_automodel` docstring.

`load_model` now also forwards the detected class as `automodel=` to `StandardizedTransformer` instead of letting it re-detect (one config read instead of two).

## Tests

`test_detect_automodel.py`: text tower selected for `yujiepan/llama-3.2-vision-tiny-random`; no-op for `yujiepan/gemma-3-tiny-random`; `ValueError` for `yujiepan/llama-4-tiny-random` (documents the 4.56 behavior — will need updating if a newer transformers makes `Llama4ForCausalLM` buildable from the composite config); end-to-end `load_model(..., text_only=True)` returns a `StandardizedTransformer` over `MllamaForCausalLM` and traces logits. `test_model_renaming.py` on gpt2 unchanged. 26 passed.

---
*Written by Claude (Fable 5) via Claude Code, supervised by @Butanium.*
Co-Authored-By: Claude <noreply@anthropic.com>
