### PR TITLE
Read attention_interface_1: the nnsight 0.8 label for the attention call

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,12 @@
   transformers 4.x and 5.x. Verified on GPT-2, Bloom, Llama-style (SmolLM2) and
   GPT-NeoX (Pythia).
 
+- **Attention probabilities work on nnsight 0.8.** nnsight 0.8 labels an
+  assignment and a call on one per-name counter, so the attention forward's
+  `attention_interface = ...` binding is `attention_interface_0` and the call is
+  `attention_interface_1`. The source functions read the call. Requires
+  `nnsight>=0.8`, now declared.
+
 ## v1.3.0
 
 ### Breaking Changes

--- a/nnterp/rename_utils.py
+++ b/nnterp/rename_utils.py
@@ -429,7 +429,7 @@ def bloom_attention_prob_source(attention_module, return_module_source: bool = F
 
 
 def default_attention_prob_source(attention_module, return_module_source: bool = False):
-    source = attention_module.source.attention_interface_0.source
+    source = attention_module.source.attention_interface_1.source
     if return_module_source:
         return source
     else:
@@ -437,7 +437,7 @@ def default_attention_prob_source(attention_module, return_module_source: bool =
 
 
 def gpt2_attention_prob_source(attention_module, return_module_source: bool = False):
-    source = attention_module.source.attention_interface_0.source
+    source = attention_module.source.attention_interface_1.source
     if return_module_source:
         return source
     else:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ classifiers = [
     "Operating System :: OS Independent",
 ]
 dependencies = [
-    "nnsight>=0.6",
+    "nnsight>=0.8",
     "transformers",
 ]
 [project.optional-dependencies]


### PR DESCRIPTION
nnsight 0.8 counts assignments and calls on one per-name counter, so the attention forward's `attention_interface = ...` binding is labeled `attention_interface_0` and the call it then makes is `attention_interface_1`. nnterp read `_0` — the binding — so `StandardizedTransformer(..., enable_attention_probs=True)` raised `SourceNotAvailable` at construction on every family that dispatches through `ALL_ATTENTION_FUNCTIONS`.

The fix is the minimal one: the two source-function lines read `attention_interface_1`, and `pyproject.toml` declares `nnsight>=0.8` — the version whose labels these are (it previously said `>=0.6`, which cannot import this branch).

No other behavior changes. Verified with the pre-existing, untouched test suite: `test_probabilities.py` was red at construction before and passes on gpt2, Bloom, and SmolLM2 after.

Note for release sequencing: `nnsight>=0.8` is not yet satisfiable from PyPI (latest published is 0.7.0), so nnsight's release goes out before this package's.

🤖 Generated with [Claude Code](https://claude.com/claude-code)